### PR TITLE
[FEATURE] content dependant notification e-mail subject

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -33,6 +33,7 @@ namespace OliverHader\IrreWorkspaces\Service;
 class ConfigurationService implements \TYPO3\CMS\Core\SingletonInterface {
 
 	const KEY_NotificationSubject = 'notificationSubject';
+	const KEY_NotificationSubjectExcludedNodes = 'notificationSubjectExcludedNodes';
 	const KEY_NotificationMessageTemplate = 'notificationMessageTemplate';
 	const KEY_NotificationMessageTemplateHtml = 'notificationMessageTemplateHtml';
 	const KEY_EnableFlexFormRendering = 'enableFlexFormRendering';
@@ -72,6 +73,10 @@ class ConfigurationService implements \TYPO3\CMS\Core\SingletonInterface {
 	 */
 	public function getNotificationSubject() {
 		return $this->get(self::KEY_NotificationSubject);
+	}
+
+	public function getNotificationSubjectExcludedNodes(){
+		return $this->get(self::KEY_NotificationSubjectExcludedNodes);
 	}
 
 	/**

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,5 +1,8 @@
-	# cat=basic//10; type=string; label=notificationMessageSubject: Subject of notifications
-notificationSubject = TYPO3 Workspace Änderungen
+	# cat=basic//10; type=string; label=notificationMessageSubject: Subject of notifications 1$=MainNode; 2$=User Realname; 3$= Stage Title
+notificationSubject = TYPO3 Workspace: '%1$s' von '%2$s' auf '%3$s'
+
+	# cat=basic//10; type=string; label=notificationSubjectExcludedNodes: Excluded page nodes for the notificationSubject (e.g. MyExcludedNode1,MyExcludedNode2)
+notificationSubjectExcludedNodes =
 
 	# cat=basic//10; type=string; label=notificationMessageTemplate: Subject of notifications
 notificationMessageTemplate = EXT:irre_workspaces/Resources/Private/Templates/Notification/Message.txt


### PR DESCRIPTION
The subject of the notification E-mail contains now information about the touched main nodes, the backenduser and the stage.

The main node is the first node of the touched rootline. In some cases it might be helpful to exclude some nodes. This can be configured by adding a comma separated list of nodes in the notificationSubjectExcludedNodes property
